### PR TITLE
fix: 修复 warpConn nonce 计数器共用和 TLS 1.2 record 长度溢出

### DIFF
--- a/client.go
+++ b/client.go
@@ -256,7 +256,7 @@ func NewClient(ctx context.Context, config *ClientConfig) (net.Conn, error) {
 		}
 		// 服务端回复验证通过
 		logger.Debugln("verify ok")
-		return newWarpConn(uconn.GetUnderlyingConn(), aead, config.OverlayData, seqNumerOne, isTLS13), nil
+		return NewWarpConn(uconn.GetUnderlyingConn(), aead, config.OverlayData, seqNumerOne, isTLS13), nil
 	}
 	uconn.Close()
 	return nil, ErrVerifyFailed

--- a/server.go
+++ b/server.go
@@ -250,7 +250,7 @@ func (l *Listener) handshake(clientConn net.Conn) (net.Conn, error) {
 	}
 
 	// [8] 返回加密连接
-	return newWarpConn(clientConn, result.aead, overlayData, seq, fo.isTLS13), nil
+	return NewWarpConn(clientConn, result.aead, overlayData, seq, fo.isTLS13), nil
 }
 
 // —— 类型定义 ——

--- a/utils.go
+++ b/utils.go
@@ -76,8 +76,8 @@ type handshakeMsg struct {
 type tlsRecord struct {
 	recordType    uint8
 	version       uint16
-	recordData    []byte           // 原始 record payload
-	handshakeMsgs []handshakeMsg   // Handshake record 时自动解析的各条握手消息
+	recordData    []byte         // 原始 record payload
+	handshakeMsgs []handshakeMsg // Handshake record 时自动解析的各条握手消息
 }
 
 func newTLSRecord(recordType uint8, version uint16, recordData []byte) *tlsRecord {
@@ -198,7 +198,7 @@ type warpConn struct {
 	net.Conn
 	aead        cipher.AEAD
 	overlayData byte
-	wSeq        [8]byte // 写计数器：TLS 1.3 隐式 nonce（读写独立，见 newWarpConn）
+	wSeq        [8]byte // 写计数器：TLS 1.3 隐式 nonce（读写独立，见 NewWarpConn）
 	rSeq        [8]byte // 读计数器
 	isTLS13     bool
 	lockRead    *sync.Mutex
@@ -207,7 +207,7 @@ type warpConn struct {
 	maxPayload  int
 }
 
-func newWarpConn(conn net.Conn, aead cipher.AEAD, overlayData byte, seq [8]byte, isTLS13 bool) *warpConn {
+func NewWarpConn(conn net.Conn, aead cipher.AEAD, overlayData byte, seq [8]byte, isTLS13 bool) *warpConn {
 	if isTLS13 {
 		seq = seqNumerOne // TLS 1.3 隐式 seq：两端各自从 seqNumerOne 独立计数
 	}

--- a/utils.go
+++ b/utils.go
@@ -50,6 +50,7 @@ func generateNonce(NonceSize int, SessionKey []byte, ExpireSecond uint32) ([]byt
 var versionTLS12 = uint16(utls.VersionTLS12)
 
 const recordHeaderLen = 5
+const explicitNonceLen = 8 // TLS 1.2 nonce_explicit 长度，计入 recordData
 const (
 	recordTypeChangeCipherSpec = 20
 	recordTypeAlert            = 21
@@ -197,7 +198,8 @@ type warpConn struct {
 	net.Conn
 	aead        cipher.AEAD
 	overlayData byte
-	seq         [8]byte
+	wSeq        [8]byte // 写计数器：TLS 1.3 隐式 nonce（读写独立，见 newWarpConn）
+	rSeq        [8]byte // 读计数器
 	isTLS13     bool
 	lockRead    *sync.Mutex
 	lockWrite   *sync.Mutex
@@ -207,17 +209,22 @@ type warpConn struct {
 
 func newWarpConn(conn net.Conn, aead cipher.AEAD, overlayData byte, seq [8]byte, isTLS13 bool) *warpConn {
 	if isTLS13 {
-		seq = seqNumerOne // TLS 1.3 隐式 seq：两端必须一致
+		seq = seqNumerOne // TLS 1.3 隐式 seq：两端各自从 seqNumerOne 独立计数
+	}
+	maxPayload := 0xFFFF - aead.Overhead() - recordHeaderLen
+	if !isTLS13 {
+		maxPayload -= explicitNonceLen
 	}
 	return &warpConn{
 		Conn:        conn,
 		lockRead:    &sync.Mutex{},
 		lockWrite:   &sync.Mutex{},
 		rawInput:    &bytes.Buffer{},
-		maxPayload:  0xFFFF - aead.Overhead() - recordHeaderLen,
+		maxPayload:  maxPayload,
 		aead:        aead,
 		overlayData: overlayData,
-		seq:         seq,
+		wSeq:        seq,
+		rSeq:        seq, // TLS 1.2 下不用（显式 nonce），置同值无副作用
 		isTLS13:     isTLS13,
 	}
 }
@@ -231,12 +238,12 @@ func (w *warpConn) Write(b []byte) (int, error) {
 		if m > w.maxPayload {
 			m = w.maxPayload
 		}
-		data := w.aead.Seal(nil, w.seq[:], b[:m], nil)
+		data := w.aead.Seal(nil, w.wSeq[:], b[:m], nil)
 		if !w.isTLS13 {
-			data = append(w.seq[:], data...) // TLS 1.2: seq 作为 nonce_explicit 传输
+			data = append(w.wSeq[:], data...) // TLS 1.2: seq 作为 nonce_explicit 传输
 		}
 		record := newTLSRecord(recordTypeApplicationData, versionTLS12, data)
-		incSeq(w.seq[:])
+		incSeq(w.wSeq[:])
 		_, err := record.writeTo(w.Conn)
 		if err != nil {
 			return wrote, err
@@ -267,21 +274,21 @@ func (w *warpConn) Read(b []byte) (int, error) {
 	data := record.recordData
 	var nonce, ciphertext []byte
 	if w.isTLS13 {
-		nonce = w.seq[:]
+		nonce = w.rSeq[:]
 		ciphertext = data
 	} else {
-		if len(data) < 8 {
+		if len(data) < explicitNonceLen {
 			return 0, ErrDecryptFailed
 		}
-		nonce = data[:8]
-		ciphertext = data[8:]
+		nonce = data[:explicitNonceLen]
+		ciphertext = data[explicitNonceLen:]
 	}
 	plaintext, err := w.aead.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
 		return 0, err
 	}
 	if w.isTLS13 {
-		incSeq(w.seq[:])
+		incSeq(w.rSeq[:])
 	}
 	n := copy(b, plaintext)
 	if n < len(plaintext) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,115 @@
+package reality_test
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/howmp/reality"
+)
+
+const tlsRecordHeaderLen = 5
+
+var firstSequenceNumber = [8]byte{0, 0, 0, 0, 0, 0, 0, 1}
+
+type memoryConn struct {
+	input  bytes.Buffer
+	output bytes.Buffer
+}
+
+func (c *memoryConn) Read(p []byte) (int, error)       { return c.input.Read(p) }
+func (c *memoryConn) Write(p []byte) (int, error)      { return c.output.Write(p) }
+func (c *memoryConn) Close() error                     { return nil }
+func (c *memoryConn) LocalAddr() net.Addr              { return nil }
+func (c *memoryConn) RemoteAddr() net.Addr             { return nil }
+func (c *memoryConn) SetDeadline(time.Time) error      { return nil }
+func (c *memoryConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *memoryConn) SetWriteDeadline(time.Time) error { return nil }
+
+func (c *memoryConn) receive(data []byte) {
+	c.input.Write(data)
+}
+
+func newTestAEAD(t *testing.T) cipher.AEAD {
+	t.Helper()
+	block, err := aes.NewCipher(make([]byte, 16))
+	if err != nil {
+		t.Fatal(err)
+	}
+	aead, err := cipher.NewGCMWithNonceSize(block, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return aead
+}
+
+func TestWarpConnTLS13BidirectionalWriteBeforeRead(t *testing.T) {
+	clientWire := &memoryConn{}
+	serverWire := &memoryConn{}
+	client := reality.NewWarpConn(clientWire, newTestAEAD(t), 0, firstSequenceNumber, true)
+	server := reality.NewWarpConn(serverWire, newTestAEAD(t), 0, firstSequenceNumber, true)
+
+	clientPayload := []byte("client payload")
+	serverPayload := []byte("server payload")
+	if _, err := client.Write(clientPayload); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.Write(serverPayload); err != nil {
+		t.Fatal(err)
+	}
+
+	clientWire.receive(serverWire.output.Bytes())
+	serverWire.receive(clientWire.output.Bytes())
+
+	buf := make([]byte, 64)
+	n, err := client.Read(buf)
+	if err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+	if !bytes.Equal(buf[:n], serverPayload) {
+		t.Fatalf("client payload mismatch: got %q, want %q", buf[:n], serverPayload)
+	}
+	n, err = server.Read(buf)
+	if err != nil {
+		t.Fatalf("server read: %v", err)
+	}
+	if !bytes.Equal(buf[:n], clientPayload) {
+		t.Fatalf("server payload mismatch: got %q, want %q", buf[:n], clientPayload)
+	}
+}
+
+func TestWarpConnTLS12MaximumRecordLength(t *testing.T) {
+	wire := &memoryConn{}
+	writer := reality.NewWarpConn(wire, newTestAEAD(t), 0, firstSequenceNumber, false)
+	payload := bytes.Repeat([]byte{0x5a}, 0xFFFF-16-tlsRecordHeaderLen)
+	if _, err := writer.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+
+	raw := wire.output.Bytes()
+	for remaining := raw; len(remaining) > 0; {
+		if len(remaining) < tlsRecordHeaderLen {
+			t.Fatalf("truncated record header: %d bytes", len(remaining))
+		}
+		recordLen := int(remaining[3])<<8 | int(remaining[4])
+		totalLen := tlsRecordHeaderLen + recordLen
+		if totalLen > len(remaining) {
+			t.Fatalf("record length exceeds available data: record=%d, available=%d", totalLen, len(remaining))
+		}
+		remaining = remaining[totalLen:]
+	}
+
+	wire.receive(raw)
+	reader := reality.NewWarpConn(wire, newTestAEAD(t), 0, firstSequenceNumber, false)
+	got := make([]byte, len(payload))
+	if _, err := io.ReadFull(reader, got); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("payload mismatch")
+	}
+}


### PR DESCRIPTION
## 变更内容

- 将 `warpConn` 的单一 `seq` 拆分为 `wSeq` 和 `rSeq`，避免 TLS 1.3 读写方向共用 nonce 计数器。
- TLS 1.2 路径的 `maxPayload` 额外减去 8 字节 `nonce_explicit`，避免最大分片时 TLS record 长度溢出。

## 问题原因

TLS 1.3 使用隐式 nonce，接收端需要根据本地读计数器重建 nonce。原实现中读写共用同一个 `seq`，双向并发传输时，本端写操作会推进读方向需要使用的 nonce，导致接收端用错误 nonce 解密，最终出现 `cipher: message authentication failed`。

TLS 1.2 路径会把 8 字节显式 nonce 写入 record data。原来的 `maxPayload` 只减去了 AEAD tag 和 record header，未扣除这 8 字节，最大分片时可能超过 TLS record 16-bit 长度上限，导致长度回绕和流错位。