### PR TITLE
fix: 隔离 warpConn 双向 AEAD 密钥

### DIFF
--- a/client.go
+++ b/client.go
@@ -256,7 +256,12 @@ func NewClient(ctx context.Context, config *ClientConfig) (net.Conn, error) {
 		}
 		// 服务端回复验证通过
 		logger.Debugln("verify ok")
-		return NewWarpConn(uconn.GetUnderlyingConn(), aead, config.OverlayData, seqNumerOne, isTLS13), nil
+		writeAEAD, readAEAD, err := newWarpAEADs(sessionKey, true)
+		if err != nil {
+			uconn.Close()
+			return nil, err
+		}
+		return NewWarpConn(uconn.GetUnderlyingConn(), writeAEAD, readAEAD, config.OverlayData, seqNumerOne, isTLS13), nil
 	}
 	uconn.Close()
 	return nil, ErrVerifyFailed

--- a/server.go
+++ b/server.go
@@ -250,14 +250,19 @@ func (l *Listener) handshake(clientConn net.Conn) (net.Conn, error) {
 	}
 
 	// [8] 返回加密连接
-	return NewWarpConn(clientConn, result.aead, overlayData, seq, fo.isTLS13), nil
+	writeAEAD, readAEAD, err := newWarpAEADs(result.sessionKey, false)
+	if err != nil {
+		clientConn.Close()
+		return nil, err
+	}
+	return NewWarpConn(clientConn, writeAEAD, readAEAD, overlayData, seq, fo.isTLS13), nil
 }
 
 // —— 类型定义 ——
 
 type handshakeResult struct {
-	aead      cipher.AEAD
-	plaintext []byte
+	sessionKey []byte
+	plaintext  []byte
 }
 
 type flightObserver struct {
@@ -379,7 +384,7 @@ func (l *Listener) readClientHello(clientReader *bufio.Reader, logger logrus.Fie
 		return nil, err
 	}
 	logger.Debug("handshake ok")
-	return &handshakeResult{aead: aead, plaintext: plaintext}, nil
+	return &handshakeResult{sessionKey: sessionKey, plaintext: plaintext}, nil
 }
 
 // cleanupSeenRandoms 定期清理已过期的公钥记录，防止 map 无限增长。

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,7 @@ package reality
 
 import (
 	"bytes"
+	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
 	"crypto/sha256"
@@ -31,6 +32,11 @@ var Prefix = []byte("REALITY")
 const DefaultExpireSecond = 30
 
 var seqNumerOne = [8]byte{0, 0, 0, 0, 0, 0, 0, 1}
+
+var (
+	clientWriteKeyInfo = []byte("warp client write key")
+	serverWriteKeyInfo = []byte("warp server write key")
+)
 
 // generateNonce 根据SessionKey和ExpireSecond生成Nonce
 func generateNonce(NonceSize int, SessionKey []byte, ExpireSecond uint32) ([]byte, error) {
@@ -196,7 +202,8 @@ var _ OverlayData = (*warpConn)(nil)
 
 type warpConn struct {
 	net.Conn
-	aead        cipher.AEAD
+	writeAEAD   cipher.AEAD
+	readAEAD    cipher.AEAD
 	overlayData byte
 	wSeq        [8]byte // 写计数器：TLS 1.3 隐式 nonce（读写独立，见 NewWarpConn）
 	rSeq        [8]byte // 读计数器
@@ -207,11 +214,38 @@ type warpConn struct {
 	maxPayload  int
 }
 
-func NewWarpConn(conn net.Conn, aead cipher.AEAD, overlayData byte, seq [8]byte, isTLS13 bool) *warpConn {
+func newWarpAEADs(sessionKey []byte, isClient bool) (cipher.AEAD, cipher.AEAD, error) {
+	clientAEAD, err := newWarpAEAD(sessionKey, clientWriteKeyInfo)
+	if err != nil {
+		return nil, nil, err
+	}
+	serverAEAD, err := newWarpAEAD(sessionKey, serverWriteKeyInfo)
+	if err != nil {
+		return nil, nil, err
+	}
+	if isClient {
+		return clientAEAD, serverAEAD, nil
+	}
+	return serverAEAD, clientAEAD, nil
+}
+
+func newWarpAEAD(sessionKey, info []byte) (cipher.AEAD, error) {
+	key := make([]byte, len(sessionKey))
+	if _, err := io.ReadFull(hkdf.New(sha256.New, sessionKey, Prefix, info), key); err != nil {
+		return nil, err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCMWithNonceSize(block, explicitNonceLen)
+}
+
+func NewWarpConn(conn net.Conn, writeAEAD, readAEAD cipher.AEAD, overlayData byte, seq [8]byte, isTLS13 bool) *warpConn {
 	if isTLS13 {
 		seq = seqNumerOne // TLS 1.3 隐式 seq：两端各自从 seqNumerOne 独立计数
 	}
-	maxPayload := 0xFFFF - aead.Overhead() - recordHeaderLen
+	maxPayload := 0xFFFF - writeAEAD.Overhead() - recordHeaderLen
 	if !isTLS13 {
 		maxPayload -= explicitNonceLen
 	}
@@ -221,7 +255,8 @@ func NewWarpConn(conn net.Conn, aead cipher.AEAD, overlayData byte, seq [8]byte,
 		lockWrite:   &sync.Mutex{},
 		rawInput:    &bytes.Buffer{},
 		maxPayload:  maxPayload,
-		aead:        aead,
+		writeAEAD:   writeAEAD,
+		readAEAD:    readAEAD,
 		overlayData: overlayData,
 		wSeq:        seq,
 		rSeq:        seq, // TLS 1.2 下不用（显式 nonce），置同值无副作用
@@ -238,7 +273,7 @@ func (w *warpConn) Write(b []byte) (int, error) {
 		if m > w.maxPayload {
 			m = w.maxPayload
 		}
-		data := w.aead.Seal(nil, w.wSeq[:], b[:m], nil)
+		data := w.writeAEAD.Seal(nil, w.wSeq[:], b[:m], nil)
 		if !w.isTLS13 {
 			data = append(w.wSeq[:], data...) // TLS 1.2: seq 作为 nonce_explicit 传输
 		}
@@ -283,7 +318,7 @@ func (w *warpConn) Read(b []byte) (int, error) {
 		nonce = data[:explicitNonceLen]
 		ciphertext = data[explicitNonceLen:]
 	}
-	plaintext, err := w.aead.Open(nil, nonce, ciphertext, nil)
+	plaintext, err := w.readAEAD.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -50,8 +50,10 @@ func newTestAEAD(t *testing.T) cipher.AEAD {
 func TestWarpConnTLS13BidirectionalWriteBeforeRead(t *testing.T) {
 	clientWire := &memoryConn{}
 	serverWire := &memoryConn{}
-	client := reality.NewWarpConn(clientWire, newTestAEAD(t), 0, firstSequenceNumber, true)
-	server := reality.NewWarpConn(serverWire, newTestAEAD(t), 0, firstSequenceNumber, true)
+	clientWriteAEAD := newTestAEAD(t)
+	serverWriteAEAD := newTestAEAD(t)
+	client := reality.NewWarpConn(clientWire, clientWriteAEAD, serverWriteAEAD, 0, firstSequenceNumber, true)
+	server := reality.NewWarpConn(serverWire, serverWriteAEAD, clientWriteAEAD, 0, firstSequenceNumber, true)
 
 	clientPayload := []byte("client payload")
 	serverPayload := []byte("server payload")
@@ -84,7 +86,8 @@ func TestWarpConnTLS13BidirectionalWriteBeforeRead(t *testing.T) {
 
 func TestWarpConnTLS12MaximumRecordLength(t *testing.T) {
 	wire := &memoryConn{}
-	writer := reality.NewWarpConn(wire, newTestAEAD(t), 0, firstSequenceNumber, false)
+	aead := newTestAEAD(t)
+	writer := reality.NewWarpConn(wire, aead, aead, 0, firstSequenceNumber, false)
 	payload := bytes.Repeat([]byte{0x5a}, 0xFFFF-16-tlsRecordHeaderLen)
 	if _, err := writer.Write(payload); err != nil {
 		t.Fatal(err)
@@ -104,7 +107,7 @@ func TestWarpConnTLS12MaximumRecordLength(t *testing.T) {
 	}
 
 	wire.receive(raw)
-	reader := reality.NewWarpConn(wire, newTestAEAD(t), 0, firstSequenceNumber, false)
+	reader := reality.NewWarpConn(wire, aead, aead, 0, firstSequenceNumber, false)
 	got := make([]byte, len(payload))
 	if _, err := io.ReadFull(reader, got); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## 背景

PR #21 将 warpConn 的读写 sequence number 分离，符合 TLS connection state 的读写状态模型，但当前协议两端仍共享同一个 AEAD key，导致上下行从相同序号开始时复用 AES-GCM nonce。

## 变更

- 从 ECDH session key 通过 HKDF 派生 client-write 和 server-write 两个方向密钥。
- 客户端 write 使用 client-write，read 使用 server-write。
- 服务端使用相反方向绑定。
- 保留 PR #21 的双向 sequence number 和 TLS 1.2 record 长度修复。
- 保留并更新 TLS 1.3 双向传输、TLS 1.2 最大 record 回归测试。

## 验证

- go test -count=1 -timeout 90s ./...
- go vet ./...

该 PR 是 PR #21 合并后的独立后续安全修复。